### PR TITLE
Moving secrets to .env, revoking them in the process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,7 +95,7 @@ celerybeat.pid
 *.sage.py
 
 # Environments
-.env
+.env*
 .venv
 env/
 venv/

--- a/README.md
+++ b/README.md
@@ -2,7 +2,12 @@
 Analyze addresses for possible construction
 
 ## How to Run
-To run this app in development mode, run:
+
+Set the enviroment (production / test) before starting up the application
+`export DJANGO_ENV=production`
+
+
+To run this app:
 ```pdm run manage.py runserver```
 
 To change app_state to use mock apis - Uncomment the API varaibles in tamaod/settings.py

--- a/api/services/real.py
+++ b/api/services/real.py
@@ -7,7 +7,6 @@ from api.services.base import BaseNominativeQuery, BaseGISNQuery
 class RealNominativeQuery(BaseNominativeQuery):
 
     def fetch_data(self, street: str, house_number: int):
-      
       query_string = " ".join([street, str(house_number), "תל", "אביב"])
       url = "https://nominatim.openstreetmap.org/search?"
       params = {
@@ -22,7 +21,6 @@ class RealNominativeQuery(BaseNominativeQuery):
 
       try:
         response = requests.get(url, params=params, headers=headers, timeout=5)
-
         response.raise_for_status()
         data = response.json()
         places = {}

--- a/api/services/real.py
+++ b/api/services/real.py
@@ -1,11 +1,13 @@
 import requests
 import json
+import os
 from django.http import JsonResponse
 from api.services.base import BaseNominativeQuery, BaseGISNQuery
 
 class RealNominativeQuery(BaseNominativeQuery):
 
     def fetch_data(self, street: str, house_number: int):
+      
       query_string = " ".join([street, str(house_number), "תל", "אביב"])
       url = "https://nominatim.openstreetmap.org/search?"
       params = {
@@ -14,8 +16,8 @@ class RealNominativeQuery(BaseNominativeQuery):
       }
 
       headers = {
-        "User-Agent": "TamaApp/1.0 (eshalev@redhat.com)",
-        "Referer": "https://github.com/elai-shalev/TamaOd"
+        "User-Agent": os.getenv('USER_AGENT'),
+        "Referer": os.getenv('REFERRER')
       }
 
       try:

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:09dc9a40081f0cb6d8725ecbacda3c20956e41dc6b90516969f24d98b3b74a7f"
+content_hash = "sha256:13f588d72fe9976d3f083821cc9849f574148689cac342226e12a1bf85cf10bc"
 
 [[metadata.targets]]
 requires_python = "==3.13.*"
@@ -215,6 +215,17 @@ dependencies = [
 files = [
     {file = "pytest-8.3.4-py3-none-any.whl", hash = "sha256:50e16d954148559c9a74109af1eaf0c945ba2d8f30f0a3d3335edde19788b6f6"},
     {file = "pytest-8.3.4.tar.gz", hash = "sha256:965370d062bce11e73868e0335abac31b4d3de0e82f4007408d242b4f8610761"},
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.1.0"
+requires_python = ">=3.9"
+summary = "Read key-value pairs from a .env file and set them as environment variables"
+groups = ["default"]
+files = [
+    {file = "python_dotenv-1.1.0-py3-none-any.whl", hash = "sha256:d7c01d9e2293916c18baf562d95698754b0dbbb5e74d457c45d4f6561fb9d55d"},
+    {file = "python_dotenv-1.1.0.tar.gz", hash = "sha256:41f90bc6f5f177fb41f53e87666db362025010eb28f60a01c9143bfa33a2b2d5"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Default template for PDM package"
 authors = [
     {name = "Elai Shalev", email = "eshalev@redhat.com"},
 ]
-dependencies = ["django>=5.1.6", "requests>=2.32.3"]
+dependencies = ["django>=5.1.6", "requests>=2.32.3", "python-dotenv>=1.1.0"]
 requires-python = "==3.13.*"
 readme = "README.md"
 license = {text = "MIT"}

--- a/tamaod/settings.py
+++ b/tamaod/settings.py
@@ -16,16 +16,29 @@ https://docs.djangoproject.com/en/5.1/ref/settings/
 #USE_MOCK_GISN = True
 
 from pathlib import Path
+import os
+from dotenv import load_dotenv
+
+ENVIRONMENT = os.getenv('DJANGO_ENV', 'production')
+
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 
+if ENVIRONMENT == 'production':
+    dotenv_path = BASE_DIR / '.env.prod'
+elif ENVIRONMENT == 'test':
+    dotenv_path = BASE_DIR / '.env.test'
+else:  # Assume development
+    dotenv_path = BASE_DIR / '.env'
+
+load_dotenv(dotenv_path=dotenv_path)
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/5.1/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'django-insecure-rx)xu4d-^(x1inmlphs=k92c75cu+gk60sy@cejo6lzmuosu2)'
+SECRET_KEY = os.getenv('SECRET_KEY')
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True


### PR DESCRIPTION
This PR will close [this issue ](https://github.com/elai-shalev/TamaOd/issues/4), moving django secrets to .env files, and revoking them. Also moved personal (not secret) information in services to env.

## Summary by Sourcery

Move sensitive and personal configuration values to environment variables using .env files, and update project to load these values securely based on environment.

Enhancements:
- Replace hardcoded secrets and personal information with environment variables loaded from .env files.
- Add python-dotenv as a dependency to manage environment variables.

Documentation:
- Update README with instructions for setting the environment and running the application.